### PR TITLE
Handle RequiredAttribute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,13 +2,11 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  
   <!-- Run "dotnet list package (dash,dash)outdated" to see the latest versions of each package.-->
-
   <ItemGroup Label="Dependencies">
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" Condition="$(TargetFramework.StartsWith('netstandard'))" />
     <PackageVersion Include="System.Text.Json" Version="8.0.3" Condition="$(TargetFramework.StartsWith('netstandard'))" />
   </ItemGroup>
-
   <ItemGroup Label="Build Dependencies">
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,7 @@
   <ItemGroup Label="Build Dependencies">
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageVersion Include="Nunit" Version="4.1.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.1.0" />
+    <PackageVersion Include="xunit" Version="2.7.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.8" />
   </ItemGroup>
 </Project>

--- a/src/ZCS.DataContractResolver/DataContractResolver.cs
+++ b/src/ZCS.DataContractResolver/DataContractResolver.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -85,7 +85,7 @@ namespace System.Text.Json.Serialization.Metadata
                     propertyName = attr?.Name ?? fieldInfo.Name;
                     propertyType = fieldInfo.FieldType;
                     getValue = fieldInfo.GetValue;
-                    setValue = (obj, value) => fieldInfo.SetValue(obj, value);
+                    setValue = fieldInfo.SetValue;
                 }
                 else
                 if (memberInfo.MemberType == MemberTypes.Property && memberInfo is PropertyInfo propertyInfo)
@@ -98,7 +98,7 @@ namespace System.Text.Json.Serialization.Metadata
                     }
                     if (propertyInfo.CanWrite)
                     {
-                        setValue = (obj, value) => propertyInfo.SetValue(obj, value);
+                        setValue = propertyInfo.SetValue;
                     }
                 }
                 else

--- a/src/ZCS.DataContractResolver/DataContractResolver.cs
+++ b/src/ZCS.DataContractResolver/DataContractResolver.cs
@@ -1,4 +1,5 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -117,8 +118,18 @@ namespace System.Text.Json.Serialization.Metadata
 
                 if (attr != null)
                 {
+                    jsonPropertyInfo.IsRequired = attr.IsRequired;
                     jsonPropertyInfo.Order = attr.Order;
                     jsonPropertyInfo.ShouldSerialize = !attr.EmitDefaultValue ? ((_, obj) => !IsNullOrDefault(obj)) : null;
+                }
+                
+                if (!jsonPropertyInfo.IsRequired)
+                {
+                    var requiredAttr = memberInfo.GetCustomAttribute<RequiredAttribute>();
+                    if (requiredAttr != null)
+                    {
+                        jsonPropertyInfo.IsRequired = true;
+                    }
                 }
 
                 yield return jsonPropertyInfo;

--- a/src/ZCS.DataContractResolver/ZCS.DataContractResolver.csproj
+++ b/src/ZCS.DataContractResolver/ZCS.DataContractResolver.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(ClassLibTargetFrameworks)</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Condition="$(TargetFramework.StartsWith('netstandard'))"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Condition="$(TargetFramework.StartsWith('netstandard'))" />
+    <PackageReference Include="System.Text.Json" Condition="$(TargetFramework.StartsWith('netstandard'))" />
   </ItemGroup>
 </Project>

--- a/test/ZCS.DataContractResolver.Tests/DataContractResolverTests.cs
+++ b/test/ZCS.DataContractResolver.Tests/DataContractResolverTests.cs
@@ -1,8 +1,9 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using NUnit.Framework;
+using System.Text.Json.Serialization;
+using Xunit;
 
 namespace ZCS.DataContractResolver.Tests
 {
@@ -34,7 +35,7 @@ namespace ZCS.DataContractResolver.Tests
 
     public class PersonWithoutContractWithDataMember
     {
-        [DataMember(Name ="full_name")]
+        [DataMember(Name = "full_name")]
         public string FullName { get; set; }
 
         [IgnoreDataMember]
@@ -235,7 +236,7 @@ namespace ZCS.DataContractResolver.Tests
     public class PersonContractWithBasicTypes
     {
         public byte Byte { get; set; }
-        
+
         public sbyte SByte { get; set; }
 
         public short Short { get; set; }
@@ -275,196 +276,201 @@ namespace ZCS.DataContractResolver.Tests
 
     public class DataContractResolverTests
     {
-        private static System.Collections.IEnumerable TestCases()
+        public static TheoryData<JsonIgnoreCondition, object> TestCases()
         {
-            var ignoreConditions = new List<System.Text.Json.Serialization.JsonIgnoreCondition>()
+            var data = new TheoryData<JsonIgnoreCondition, object>();
+
+            var ignoreConditions = new List<JsonIgnoreCondition>()
             {
-                System.Text.Json.Serialization.JsonIgnoreCondition.Never,
-                System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault,
-                System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+                JsonIgnoreCondition.Never,
+                JsonIgnoreCondition.WhenWritingDefault,
+                JsonIgnoreCondition.WhenWritingNull
             };
 
             foreach (var ignoreCondition in ignoreConditions)
             {
-                yield return new TestCaseData(ignoreCondition, false);
-                yield return new TestCaseData(ignoreCondition, true);
+                data.Add(ignoreCondition, false);
+                data.Add(ignoreCondition, true);
 
-                yield return new TestCaseData(ignoreCondition, 'a');
-                yield return new TestCaseData(ignoreCondition, (byte)1);
-                yield return new TestCaseData(ignoreCondition, (sbyte)-1);
+                data.Add(ignoreCondition, 'a');
+                data.Add(ignoreCondition, (byte)1);
+                data.Add(ignoreCondition, (sbyte)-1);
 
-                yield return new TestCaseData(ignoreCondition, short.MinValue);
-                yield return new TestCaseData(ignoreCondition, short.MaxValue);
+                data.Add(ignoreCondition, short.MinValue);
+                data.Add(ignoreCondition, short.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, int.MinValue);
-                yield return new TestCaseData(ignoreCondition, int.MaxValue);
+                data.Add(ignoreCondition, int.MinValue);
+                data.Add(ignoreCondition, int.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, long.MinValue);
-                yield return new TestCaseData(ignoreCondition, Int64.MaxValue);
+                data.Add(ignoreCondition, long.MinValue);
+                data.Add(ignoreCondition, Int64.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, ushort.MinValue);
-                yield return new TestCaseData(ignoreCondition, ushort.MaxValue);
+                data.Add(ignoreCondition, ushort.MinValue);
+                data.Add(ignoreCondition, ushort.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, uint.MinValue);
-                yield return new TestCaseData(ignoreCondition, uint.MaxValue);
+                data.Add(ignoreCondition, uint.MinValue);
+                data.Add(ignoreCondition, uint.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, ulong.MinValue);
-                yield return new TestCaseData(ignoreCondition, ulong.MaxValue);
+                data.Add(ignoreCondition, ulong.MinValue);
+                data.Add(ignoreCondition, ulong.MaxValue);
 
-                yield return new TestCaseData(ignoreCondition, 1.2m);
+                data.Add(ignoreCondition, 1.2m);
 
-                yield return new TestCaseData(ignoreCondition, string.Empty);
-                yield return new TestCaseData(ignoreCondition, "Hello");
+                data.Add(ignoreCondition, string.Empty);
+                data.Add(ignoreCondition, "Hello");
 
-                yield return new TestCaseData(ignoreCondition, default(DateTime));
-                yield return new TestCaseData(ignoreCondition, DateTime.Now);
+                data.Add(ignoreCondition, default(DateTime));
+                data.Add(ignoreCondition, DateTime.Now);
 
-                yield return new TestCaseData(ignoreCondition, default(TimeSpan));
-                yield return new TestCaseData(ignoreCondition, TimeSpan.FromSeconds(1234567890));
+                data.Add(ignoreCondition, default(TimeSpan));
+                data.Add(ignoreCondition, TimeSpan.FromSeconds(1234567890));
 
-                yield return new TestCaseData(ignoreCondition, (1, 2));
-                yield return new TestCaseData(ignoreCondition, (1, "2"));
-                yield return new TestCaseData(ignoreCondition, ("1", "2"));
+                data.Add(ignoreCondition, (1, 2));
+                data.Add(ignoreCondition, (1, "2"));
+                data.Add(ignoreCondition, ("1", "2"));
 
-                yield return new TestCaseData(ignoreCondition, new KeyValuePair<int, int>(1, 2));
-                yield return new TestCaseData(ignoreCondition, new KeyValuePair<int, string>(1, "2"));
-                yield return new TestCaseData(ignoreCondition, new KeyValuePair<string, string>("1", "2"));
+                data.Add(ignoreCondition, new KeyValuePair<int, int>(1, 2));
+                data.Add(ignoreCondition, new KeyValuePair<int, string>(1, "2"));
+                data.Add(ignoreCondition, new KeyValuePair<string, string>("1", "2"));
 
-                yield return new TestCaseData(ignoreCondition, new List<int>());
-                yield return new TestCaseData(ignoreCondition, (List<int>)[0, 1, 2, 3]);
-                yield return new TestCaseData(ignoreCondition, (List<string>)["0", "1", "2", "3"]);
+                data.Add(ignoreCondition, new List<int>());
+                data.Add(ignoreCondition, (List<int>)[0, 1, 2, 3]);
+                data.Add(ignoreCondition, (List<string>)["0", "1", "2", "3"]);
 
-                yield return new TestCaseData(ignoreCondition, Array.Empty<int>());
-                yield return new TestCaseData(ignoreCondition, (int[])[0, 1, 2, 3]);
-                yield return new TestCaseData(ignoreCondition, (string[])["0", "1", "2", "3"]);
+                data.Add(ignoreCondition, Array.Empty<int>());
+                data.Add(ignoreCondition, (int[])[0, 1, 2, 3]);
+                data.Add(ignoreCondition, (string[])["0", "1", "2", "3"]);
 
-                yield return new TestCaseData(ignoreCondition, new Dictionary<int, int> { { 1, 2 }, { 3, 4 } });
-                yield return new TestCaseData(ignoreCondition, new Dictionary<int, string> { { 1, "2" }, { 3, "4" } });
-                yield return new TestCaseData(ignoreCondition, new Dictionary<string, string> { { "1", "2" }, { "3", "4" } });
+                data.Add(ignoreCondition, new Dictionary<int, int> { { 1, 2 }, { 3, 4 } });
+                data.Add(ignoreCondition, new Dictionary<int, string> { { 1, "2" }, { 3, "4" } });
+                data.Add(ignoreCondition, new Dictionary<string, string> { { "1", "2" }, { "3", "4" } });
 
-                yield return new TestCaseData(ignoreCondition, new HashSet<int>());
-                yield return new TestCaseData(ignoreCondition, (HashSet<int>)[0, 1, 2, 3]);
-                yield return new TestCaseData(ignoreCondition, (HashSet<string>)["0", "1", "2", "3"]);
+                data.Add(ignoreCondition, new HashSet<int>());
+                data.Add(ignoreCondition, (HashSet<int>)[0, 1, 2, 3]);
+                data.Add(ignoreCondition, (HashSet<string>)["0", "1", "2", "3"]);
 
-                yield return new TestCaseData(ignoreCondition, new Generic<int>{ Value = 1 });
-                yield return new TestCaseData(ignoreCondition, new Generic<string> { Value = "1" });
+                data.Add(ignoreCondition, new Generic<int>{ Value = 1 });
+                data.Add(ignoreCondition, new Generic<string> { Value = "1" });
 
-                yield return new TestCaseData(ignoreCondition, new GenericWithConstructor<int>(1));
-                yield return new TestCaseData(ignoreCondition, new GenericWithConstructor<string>("1"));
+                data.Add(ignoreCondition, new GenericWithConstructor<int>(1));
+                data.Add(ignoreCondition, new GenericWithConstructor<string>("1"));
 
-                yield return new TestCaseData(ignoreCondition, PersonEnum.First);
-                yield return new TestCaseData(ignoreCondition, PersonEnum.Second);
-                yield return new TestCaseData(ignoreCondition, PersonEnum.Third);
-                yield return new TestCaseData(ignoreCondition, PersonEnum.Fourth);
+                data.Add(ignoreCondition, PersonEnum.First);
+                data.Add(ignoreCondition, PersonEnum.Second);
+                data.Add(ignoreCondition, PersonEnum.Third);
+                data.Add(ignoreCondition, PersonEnum.Fourth);
 
-                yield return new TestCaseData(ignoreCondition, new Person());
-                yield return new TestCaseData(ignoreCondition, new Person() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new Person() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new Person() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new Person());
+                data.Add(ignoreCondition, new Person() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new Person() { Age = 21 });
+                data.Add(ignoreCondition, new Person() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithoutDefaultConstructor("John Doe", 21));
+                data.Add(ignoreCondition, new PersonWithoutDefaultConstructor("John Doe", 21));
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithNonPublicMember());
-                yield return new TestCaseData(ignoreCondition, new PersonWithNonPublicMember() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithNonPublicMember());
+                data.Add(ignoreCondition, new PersonWithNonPublicMember() { FullName = "John Doe" });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithoutDataMember());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithoutDataMember() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithoutDataMember());
+                data.Add(ignoreCondition, new PersonContractWithoutDataMember() { FullName = "John Doe" });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithIgnore());
-                yield return new TestCaseData(ignoreCondition, new PersonWithIgnore() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithIgnore() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithIgnore() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithIgnore());
+                data.Add(ignoreCondition, new PersonWithIgnore() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithIgnore() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithIgnore() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithoutContractWithDataMember());
-                yield return new TestCaseData(ignoreCondition, new PersonWithoutContractWithDataMember() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithoutContractWithDataMember() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithoutContractWithDataMember() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithoutContractWithDataMember());
+                data.Add(ignoreCondition, new PersonWithoutContractWithDataMember() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithoutContractWithDataMember() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithoutContractWithDataMember() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonGetSet());
-                yield return new TestCaseData(ignoreCondition, new PersonGetSet() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonGetSet() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonGetSet() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonGetSet());
+                data.Add(ignoreCondition, new PersonGetSet() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonGetSet() { Age = 21 });
+                data.Add(ignoreCondition, new PersonGetSet() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContract());
-                yield return new TestCaseData(ignoreCondition, new PersonContract() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContract() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContract() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonContract());
+                data.Add(ignoreCondition, new PersonContract() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContract() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContract() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractMemberGetter());
-                yield return new TestCaseData(ignoreCondition, new PersonContractMemberGetter() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractMemberGetter());
+                data.Add(ignoreCondition, new PersonContractMemberGetter() { FullName = "John Doe" });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNonPublicMember());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNonPublicMember() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithNonPublicMember());
+                data.Add(ignoreCondition, new PersonContractWithNonPublicMember() { FullName = "John Doe" });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractOverrideName());
-                yield return new TestCaseData(ignoreCondition, new PersonContractOverrideName() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractOverrideName() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractOverrideName() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonContractOverrideName());
+                data.Add(ignoreCondition, new PersonContractOverrideName() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractOverrideName() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractOverrideName() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractOrdered());
-                yield return new TestCaseData(ignoreCondition, new PersonContractOrdered() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractOrdered() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractOrdered() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonContractOrdered());
+                data.Add(ignoreCondition, new PersonContractOrdered() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractOrdered() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractOrdered() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary());
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21, Friends = new Dictionary<int, Person> { { 1, new Person() { FullName = "John Doe", Age = 21 } }, { 2, new Person() { FullName = "James Doe", Age = 22 } } } });
-                yield return new TestCaseData(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21, Dict = new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } } });
+                data.Add(ignoreCondition, new PersonWithDictionary());
+                data.Add(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithDictionary() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21, Friends = new Dictionary<int, Person> { { 1, new Person() { FullName = "John Doe", Age = 21 } }, { 2, new Person() { FullName = "James Doe", Age = 22 } } } });
+                data.Add(ignoreCondition, new PersonWithDictionary() { FullName = "John Doe", Age = 21, Dict = new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } } });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithList());
-                yield return new TestCaseData(ignoreCondition, new PersonWithList() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithList() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }] });
-                yield return new TestCaseData(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21, List = [0, 1, 2, 3, 4] });
+                data.Add(ignoreCondition, new PersonWithList());
+                data.Add(ignoreCondition, new PersonWithList() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithList() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }] });
+                data.Add(ignoreCondition, new PersonWithList() { FullName = "John Doe", Age = 21, List = [0, 1, 2, 3, 4] });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet());
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }, new() { FullName = "James Doe", Age = 22 }] });
-                yield return new TestCaseData(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21, Set = [0, 1, 2, 3, 4] });
+                data.Add(ignoreCondition, new PersonWithSet());
+                data.Add(ignoreCondition, new PersonWithSet() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithSet() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }, new() { FullName = "James Doe", Age = 22 }] });
+                data.Add(ignoreCondition, new PersonWithSet() { FullName = "John Doe", Age = 21, Set = [0, 1, 2, 3, 4] });
 
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray());
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }, new() { FullName = "James Doe", Age = 22 }] });
-                yield return new TestCaseData(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21, Array = [0, 1, 2, 3, 4] });
+                data.Add(ignoreCondition, new PersonWithArray());
+                data.Add(ignoreCondition, new PersonWithArray() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonWithArray() { Age = 21 });
+                data.Add(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21, Friends = [new() { FullName = "John Doe", Age = 21 }, new() { FullName = "James Doe", Age = 22 }] });
+                data.Add(ignoreCondition, new PersonWithArray() { FullName = "John Doe", Age = 21, Array = [0, 1, 2, 3, 4] });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithIgnore());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithIgnore() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithIgnore() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithIgnore() { FullName = "John Doe", Age = 21 });
+                data.Add(ignoreCondition, new PersonContractWithIgnore());
+                data.Add(ignoreCondition, new PersonContractWithIgnore() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithIgnore() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractWithIgnore() { FullName = "John Doe", Age = 21 });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithStruct());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithStruct() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe", Age = 21, LastLogin = DateTime.UtcNow });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now });
+                data.Add(ignoreCondition, new PersonContractWithStruct());
+                data.Add(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithStruct() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe", Age = 21, LastLogin = DateTime.UtcNow });
+                data.Add(ignoreCondition, new PersonContractWithStruct() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.UtcNow });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now, BestFriend = new PersonWithoutDefaultConstructor("James Doe", 20)});
+                data.Add(ignoreCondition, new PersonContractWithNullable());
+                data.Add(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithNullable() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.UtcNow });
+                data.Add(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now });
+                data.Add(ignoreCondition, new PersonContractWithNullable() { FullName = "John Doe", Age = 21, LastLogin = DateTime.Now, BestFriend = new PersonWithoutDefaultConstructor("James Doe", 20)});
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithEnum());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe" });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithEnum() { Age = 21 });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe", Age = 21, Enum = PersonEnum.Second });
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe", Age = 21, Enum = PersonEnum.Second, Dict = new Dictionary<PersonEnum, string>() { { PersonEnum.Third, "3"}, { PersonEnum.Fourth, "4" } } });
+                data.Add(ignoreCondition, new PersonContractWithEnum());
+                data.Add(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe" });
+                data.Add(ignoreCondition, new PersonContractWithEnum() { Age = 21 });
+                data.Add(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe", Age = 21, Enum = PersonEnum.Second });
+                data.Add(ignoreCondition, new PersonContractWithEnum() { FullName = "John Doe", Age = 21, Enum = PersonEnum.Second, Dict = new Dictionary<PersonEnum, string>() { { PersonEnum.Third, "3"}, { PersonEnum.Fourth, "4" } } });
 
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithBasicTypes());
-                yield return new TestCaseData(ignoreCondition, new PersonContractWithBasicTypes() { Byte = 1, SByte = -1, Short = -2, UShort = 2, Int = -3, UInt = 3, Long = -4, ULong = 4, Float = 1.2f, Double = 2.345, Decimal = 12.34m, Char = 'c' });
+                data.Add(ignoreCondition, new PersonContractWithBasicTypes());
+                data.Add(ignoreCondition, new PersonContractWithBasicTypes() { Byte = 1, SByte = -1, Short = -2, UShort = 2, Int = -3, UInt = 3, Long = -4, ULong = 4, Float = 1.2f, Double = 2.345, Decimal = 12.34m, Char = 'c' });
             }
+
+            return data;
         }
 
-        [TestCaseSource(nameof(TestCases))]
-        public void Tests<T>(System.Text.Json.Serialization.JsonIgnoreCondition ignoreCondition, T obj)
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public void Tests<T>(JsonIgnoreCondition ignoreCondition, T obj)
         {
             var options = new System.Text.Json.JsonSerializerOptions()
             {
@@ -474,25 +480,25 @@ namespace ZCS.DataContractResolver.Tests
 
             var newtonsoftSettings = new JsonSerializerSettings()
             {
-                DefaultValueHandling = ignoreCondition == System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault ? DefaultValueHandling.Ignore : DefaultValueHandling.Include,
-                NullValueHandling = ignoreCondition == System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull ? NullValueHandling.Ignore : NullValueHandling.Include
+                DefaultValueHandling = ignoreCondition == JsonIgnoreCondition.WhenWritingDefault ? DefaultValueHandling.Ignore : DefaultValueHandling.Include,
+                NullValueHandling = ignoreCondition == JsonIgnoreCondition.WhenWritingNull ? NullValueHandling.Ignore : NullValueHandling.Include
             };
 
             // Serialize
             string json = System.Text.Json.JsonSerializer.Serialize(obj, options);
             string jsonExpected = JsonConvert.SerializeObject(obj, newtonsoftSettings);
 
-            Assert.That(json, Is.EqualTo(jsonExpected));
+            Assert.Equal(json, jsonExpected);
 
             // Deserialize
             T obj2 = System.Text.Json.JsonSerializer.Deserialize<T>(json, options);
             T obj3 = JsonConvert.DeserializeObject<T>(json, newtonsoftSettings);
-            
+
             string jsonExpected2 = JsonConvert.SerializeObject(obj2, newtonsoftSettings);
             string jsonExpected3 = JsonConvert.SerializeObject(obj3, newtonsoftSettings);
 
-            Assert.That(json, Is.EqualTo(jsonExpected2));
-            Assert.That(json, Is.EqualTo(jsonExpected3));
+            Assert.Equal(json, jsonExpected2);
+            Assert.Equal(json, jsonExpected3);
         }
     }
 }

--- a/test/ZCS.DataContractResolver.Tests/PortedNewtonsoftTests.cs
+++ b/test/ZCS.DataContractResolver.Tests/PortedNewtonsoftTests.cs
@@ -513,13 +513,25 @@ public class ContractResolverTests
     {
         var options = new JsonSerializerOptions()
         {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
         };
 
         var json = JsonSerializer.Serialize(new RequiredObject { AllowNullProperty = "Test" }, options);
 
         Assert.Contains("AllowNullProperty", json);
+    }
+
+    [Fact]
+    public void SerializeClassWithoutRequiredObject()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        const string json = "{}";
+
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<RequiredObject>(json, options));
     }
 
     [Fact]

--- a/test/ZCS.DataContractResolver.Tests/PortedNewtonsoftTests.cs
+++ b/test/ZCS.DataContractResolver.Tests/PortedNewtonsoftTests.cs
@@ -1,0 +1,556 @@
+namespace ZCS.DataContractResolver.Tests;
+
+using Newtonsoft.Json.Tests.TestObjects;
+using Newtonsoft.Json.Tests.TestObjects.Organization;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Text.Unicode;
+using Xunit;
+
+public class ContractResolverTests
+{
+    internal class SerializableTestObject : ISerializableTestObject
+    {
+        public SerializableTestObject(string stringValue, int intValue, DateTimeOffset dateTimeOffset, Newtonsoft.Json.Tests.TestObjects.Organization.Person personValue) : base(stringValue, intValue, dateTimeOffset, personValue)
+        {
+        }
+
+        protected SerializableTestObject(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+
+    internal class SerializableWithoutAttributeTestObject : ISerializableWithoutAttributeTestObject;
+
+    public class CustomList<T> : List<T>;
+
+    public class CustomDictionary<TKey, TValue> : Dictionary<TKey, TValue>;
+
+    public class AddressWithDataMember
+    {
+        [DataMember(Name = "CustomerAddress1")]
+        public string AddressLine1 { get; set; }
+    }
+
+    public class Book
+    {
+        public string BookName { get; set; }
+        public decimal BookPrice { get; set; }
+        public string AuthorName { get; set; }
+        public int AuthorAge { get; set; }
+        public string AuthorCountry { get; set; }
+    }
+
+    [Fact]
+    public void SerializeSerializableTestObject()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var testObject = new SerializableTestObject("stringValue", 123, DateTimeOffset.Now, new Newtonsoft.Json.Tests.TestObjects.Organization.Person());
+        var json = JsonSerializer.Serialize(testObject, options);
+
+        Assert.NotNull(json);
+    }
+
+    [Fact]
+    public void SerializeSerializableWithoutAttributeTestObject()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var testObject = new SerializableWithoutAttributeTestObject();
+        var json = JsonSerializer.Serialize(testObject, options);
+
+        Assert.NotNull(json);
+    }
+
+    [Fact]
+    public void SerializeAnswerFilterModel()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var model = new AnswerFilterModel();
+        var json = JsonSerializer.Serialize(model, options);
+
+        Assert.NotNull(json);
+    }
+
+    [Fact]
+    public void AbstractTestClass()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<AbstractTestClass>(@"{""Value"":""Value!""}", options));
+
+        var o = JsonSerializer.Deserialize<AbstractImplementationTestClass>(@"{""Value"":""Value!""}", options);
+
+        Assert.Equal("Value!", o.Value);
+    }
+
+    [Fact]
+    public void AbstractListTestClass()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<AbstractListTestClass<int>>("[1,2]", options));
+
+        var l = JsonSerializer.Deserialize<AbstractImplementationListTestClass<int>>("[1,2]", options);
+
+        Assert.Equal(2, l.Count);
+        Assert.Equal(1, l[0]);
+        Assert.Equal(2, l[1]);
+    }
+
+    [Fact]
+    public void ListInterfaceDefaultCreator()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var l = JsonSerializer.Deserialize<CustomList<int>>("[1,2,3]", options);
+
+        Assert.Equal(typeof(CustomList<int>), l.GetType());
+        Assert.Equal(3, l.Count);
+        Assert.Equal(1, l[0]);
+        Assert.Equal(2, l[1]);
+        Assert.Equal(3, l[2]);
+    }
+
+    [Fact]
+    public void DictionaryInterfaceDefaultCreator()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var d = JsonSerializer.Deserialize<CustomDictionary<string, int>>(@"{""key1"":1,""key2"":2}", options);
+
+        Assert.Equal(typeof(CustomDictionary<string, int>), d.GetType());
+        Assert.Equal(2, d.Count);
+        Assert.Equal(1, d["key1"]);
+        Assert.Equal(2, d["key2"]);
+    }
+
+    [Fact]
+    public void AbstractDictionaryTestClass()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        Assert.Throws<NotSupportedException>(() => JsonSerializer.Deserialize<AbstractDictionaryTestClass<string, int>>(@"{""key1"":1,""key2"":2}", options));
+
+        var d = JsonSerializer.Deserialize<AbstractImplementationDictionaryTestClass<string, int>>(@"{""key1"":1,""key2"":2}", options);
+
+        Assert.Equal(2, d.Count);
+        Assert.Equal(1, d["key1"]);
+        Assert.Equal(2, d["key2"]);
+    }
+
+    [Fact]
+    public void SerializeWithEscapedPropertyName()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(
+            new AddressWithDataMember
+            {
+                AddressLine1 = "value!"
+            }, options);
+
+        Assert.Equal(@"{""AddressLine1"":""value!""}", json);
+    }
+
+    [Fact(Skip = "HTML escaping is not supported in System.Text.Json yet.")]
+    public void SerializeWithHtmlEscapedPropertyName()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            // Encoder = new SomeEncoderHere(),
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var address = new AddressWithDataMember { AddressLine1 = "value!" };
+        string json = JsonSerializer.Serialize(address, options);
+
+        Assert.Contains("\"\\u003cb\\u003eAddressLine1\\u003c/b\\u003e\":\"value!\"", json);
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        JsonProperty property = root.EnumerateObject().First();
+
+        Assert.Equal("<b>AddressLine1</b>", property.Name);
+    }
+
+    [Fact]
+    public void SerializeWithSpecialCharactersInPropertyName()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(
+            new Dictionary<string, string>
+            {
+                { "abc", "value1" },
+                { "123", "value2" },
+                { "._-", "value3" },
+                { "!@#", "value4" },
+                { "$%^", "value5" },
+                { "?*(", "value6" },
+                { ")_+", "value7" },
+                { "=:,", "value8" },
+                { "&", "value10" },
+                { "<", "value11" },
+                { ">", "value12" },
+                { "'", "value13" },
+                { "\"", "value14" },
+                { "\r\n", "value15" },
+                { "\0", "value16" },
+                { "\n", "value17" },
+                { "\v", "value18" },
+                { "\u00B9", "value19" },
+            }, options);
+
+        Assert.NotNull(json);
+    }
+
+    [Fact]
+    public void SerializeWithDataMemberClassWithDataContract()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new AddressWithDataMember(), options);
+
+        Assert.Contains("AddressLine1", json);
+    }
+
+    public class PublicParameterizedConstructorWithPropertyNameConflictWithAttribute
+    {
+        public PublicParameterizedConstructorWithPropertyNameConflictWithAttribute()
+        {
+        }
+
+        [JsonPropertyName("name")]
+        public string NameParameter { get; set; }
+
+        public int Name
+        {
+            get { return Convert.ToInt32(NameParameter); }
+        }
+    }
+
+    [Fact]
+    public void SerializeWithParameterizedCreator()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new PublicParameterizedConstructorWithPropertyNameConflictWithAttribute(), options);
+
+        Assert.Contains("name", json, StringComparison.InvariantCultureIgnoreCase);
+    }
+
+    [Fact]
+    public void SerializeWithCustomOverrideCreator()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new MultipleParametrizedConstructorsJsonConstructor("value!", 1), options);
+
+        Assert.Contains("value!", json);
+        Assert.Contains("1", json);
+    }
+
+    [Fact]
+    public void SerializeInterface()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        Employee employee = new()
+        {
+            BirthDate = new DateTime(1977, 12, 30, 1, 1, 1, DateTimeKind.Utc),
+            FirstName = "Maurice",
+            LastName = "Moss",
+            Department = "IT",
+            JobTitle = "Support"
+        };
+
+        string iPersonJson = JsonSerializer.Serialize(employee, options);
+
+        Assert.Contains("Maurice", iPersonJson);
+        Assert.Contains("Moss", iPersonJson);
+        Assert.Contains("1977-12-30T01:01:01", iPersonJson);
+    }
+
+        [Fact]
+    public void SingleTypeWithMultipleContractResolvers()
+    {
+        Book book = new()
+        {
+            BookName = "The Gathering Storm",
+            BookPrice = 16.19m,
+            AuthorName = "Brandon Sanderson",
+            AuthorAge = 34,
+            AuthorCountry = "United States of America"
+        };
+
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        string json = JsonSerializer.Serialize(book, options);
+
+        Assert.Contains("The Gathering Storm", json);
+        Assert.Contains("16.19", json);
+        Assert.Contains("Brandon Sanderson", json);
+        Assert.Contains("34", json);
+        Assert.Contains("United States of America", json);
+    }
+
+    [Fact]
+    public void SerializeCompilerGeneratedMembers()
+    {
+        StructTest structTest = new()
+        {
+            IntField = 1,
+            IntProperty = 2,
+            StringField = "Field",
+            StringProperty = "Property"
+        };
+
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        string json = JsonSerializer.Serialize(structTest, options);
+
+        Assert.Contains("Field", json);
+        Assert.Contains("1", json);
+        Assert.Contains("Property", json);
+        Assert.Contains("2", json);
+    }
+
+    public class ClassWithExtensionData
+    {
+        [JsonExtensionData]
+        public IDictionary<string, JsonElement> Data { get; set; }
+    }
+
+    [Fact]
+    public void ExtensionDataGetterCanBeIteratedMultipleTimes()
+    {
+        ClassWithExtensionData myClass = new()
+        {
+            Data = new Dictionary<string, JsonElement>
+            {
+                { "SomeField", JsonDocument.Parse("\"Field\"").RootElement },
+            }
+        };
+
+        Assert.True(myClass.Data.Any());
+        Assert.True(myClass.Data.Any());
+    }
+
+    public class ClassWithShouldSerialize
+    {
+        public string Prop1 { get; set; }
+        public string Prop2 { get; set; }
+    }
+
+    [Fact]
+    public void SerializeClassWithShouldSerialize()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new ClassWithShouldSerialize { Prop1 = "Value1", Prop2 = "Value2" }, options);
+
+        Assert.Contains("Prop1", json);
+        Assert.Contains("Prop2", json);
+    }
+
+    public class ClassWithIsSpecified
+    {
+        public string Prop1 { get; set; }
+        public string Prop2 { get; set; }
+        public string Prop3 { get; set; }
+        public string Prop4 { get; set; }
+        public string Prop5 { get; set; }
+
+        public bool Prop1Specified;
+        public bool Prop2Specified { get; set; }
+        public static bool Prop3Specified { get; set; }
+        public event Func<bool> Prop4Specified;
+        public static bool Prop5Specified;
+
+        protected virtual bool OnProp4Specified()
+        {
+            return Prop4Specified?.Invoke() ?? false;
+        }
+    }
+
+    [Fact(Skip ="IgnoreIsSpecifiedMembers is not supported yet.")]
+    public void SerializeClassWithIsSpecified()
+    {
+        // DefaultContractResolver resolver = new DefaultContractResolver();
+        // resolver.IgnoreIsSpecifiedMembers = true;
+
+        // JsonObjectContract contract = (JsonObjectContract)resolver.ResolveContract(typeof(ClassWithIsSpecified));
+
+        // var property1 = contract.Properties["Prop1"];
+        // Assert.AreEqual(null, property1.GetIsSpecified);
+        // Assert.AreEqual(null, property1.SetIsSpecified);
+
+        // var property2 = contract.Properties["Prop2"];
+        // Assert.AreEqual(null, property2.GetIsSpecified);
+        // Assert.AreEqual(null, property2.SetIsSpecified);
+
+        // var property3 = contract.Properties["Prop3"];
+        // Assert.AreEqual(null, property3.GetIsSpecified);
+        // Assert.AreEqual(null, property3.SetIsSpecified);
+
+        // var property4 = contract.Properties["Prop4"];
+        // Assert.AreEqual(null, property4.GetIsSpecified);
+        // Assert.AreEqual(null, property4.SetIsSpecified);
+
+        // var property5 = contract.Properties["Prop5"];
+        // Assert.AreEqual(null, property5.GetIsSpecified);
+        // Assert.AreEqual(null, property5.SetIsSpecified);
+    }
+
+    public class RequiredPropertyTestClass
+    {
+        [Required]
+        public string Name { get; set; }
+    }
+
+    [Fact]
+    public void SerializeClassWithRequiredProperty()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new RequiredPropertyTestClass { Name = "Test" }, options);
+
+        Assert.Contains("Name", json);
+    }
+
+    public class RequiredObject
+    {
+        public string UnsetProperty { get; set; }
+        [Required]
+        public string AllowNullProperty { get; set; }
+    }
+
+    [Fact]
+    public void SerializeClassWithRequiredObject()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new RequiredObject { AllowNullProperty = "Test" }, options);
+
+        Assert.Contains("AllowNullProperty", json);
+    }
+
+    [Fact]
+    public void SerializeObject()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var json = JsonSerializer.Serialize(new object(), options);
+
+        Assert.Equal("{}", json);
+    }
+
+    [Fact]
+    public void SerializeRegex()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            TypeInfoResolver = System.Text.Json.Serialization.Metadata.DataContractResolver.Default,
+        };
+
+        var regex = new Regex("pattern");
+
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var json = JsonSerializer.Serialize(regex, options);
+            return JsonSerializer.Deserialize<Regex>(json, options);
+        });
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractDictionaryTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractDictionaryTestClass.cs
@@ -1,0 +1,33 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System.Collections.Generic;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public abstract class AbstractDictionaryTestClass<TKey, TValue> : Dictionary<TKey, TValue>
+    {
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationDictionaryTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationDictionaryTestClass.cs
@@ -1,0 +1,31 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class AbstractImplementationDictionaryTestClass<TKey, TValue> : AbstractDictionaryTestClass<TKey, TValue>
+    {
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationListTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationListTestClass.cs
@@ -1,0 +1,31 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class AbstractImplementationListTestClass<T> : AbstractListTestClass<T>
+    {
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractImplementationTestClass.cs
@@ -1,0 +1,31 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class AbstractImplementationTestClass : AbstractTestClass
+    {
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractListTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractListTestClass.cs
@@ -1,0 +1,33 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System.Collections.Generic;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public abstract class AbstractListTestClass<T> : List<T>
+    {
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractTestClass.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AbstractTestClass.cs
@@ -1,0 +1,32 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public abstract class AbstractTestClass
+    {
+        public string Value { get; set; }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/AnswerFilterModel.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/AnswerFilterModel.cs
@@ -1,0 +1,84 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Collections;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    [Serializable]
+    public class AnswerFilterModel
+    {
+        [NonSerialized]
+        private readonly IList answerValues;
+
+        /// <summary>
+        /// Initializes a new instance of the  class.
+        /// </summary>
+        public AnswerFilterModel()
+        {
+            answerValues = new[] { "answer1", "answer2" };
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether active.
+        /// </summary>
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether ja.
+        /// nach bisherigen Antworten.
+        /// </summary>
+        public bool Ja { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether handlungsbedarf.
+        /// </summary>
+        public bool Handlungsbedarf { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether beratungsbedarf.
+        /// </summary>
+        public bool Beratungsbedarf { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether unzutreffend.
+        /// </summary>
+        public bool Unzutreffend { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether unbeantwortet.
+        /// </summary>
+        public bool Unbeantwortet { get; set; }
+
+        /// <summary>
+        /// Gets the answer values.
+        /// </summary>
+        public IEnumerable AnswerValues
+        {
+            get { return answerValues; }
+        }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/ISerializableTestObject.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/ISerializableTestObject.cs
@@ -1,0 +1,109 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json.Tests.TestObjects.Organization;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    [Serializable]
+    public class ISerializableTestObject : ISerializable
+    {
+        internal string _stringValue;
+        internal int _intValue;
+        internal DateTimeOffset _dateTimeOffsetValue;
+        internal Person _personValue;
+        internal Person _nullPersonValue;
+        internal int? _nullableInt;
+        internal bool _booleanValue;
+        internal byte _byteValue;
+        internal char _charValue;
+        internal DateTime _dateTimeValue;
+        internal decimal _decimalValue;
+        internal short _shortValue;
+        internal long _longValue;
+        internal sbyte _sbyteValue;
+        internal float _floatValue;
+        internal ushort _ushortValue;
+        internal uint _uintValue;
+        internal ulong _ulongValue;
+
+        public ISerializableTestObject(string stringValue, int intValue, DateTimeOffset dateTimeOffset, Person personValue)
+        {
+            _stringValue = stringValue;
+            _intValue = intValue;
+            _dateTimeOffsetValue = dateTimeOffset;
+            _personValue = personValue;
+            _dateTimeValue = new DateTime(0, DateTimeKind.Utc);
+        }
+
+        protected ISerializableTestObject(SerializationInfo info, StreamingContext context)
+        {
+            _stringValue = info.GetString("stringValue");
+            _intValue = info.GetInt32("intValue");
+            _dateTimeOffsetValue = (DateTimeOffset)info.GetValue("dateTimeOffsetValue", typeof(DateTimeOffset));
+            _personValue = (Person)info.GetValue("personValue", typeof(Person));
+            _nullPersonValue = (Person)info.GetValue("nullPersonValue", typeof(Person));
+            _nullableInt = (int?)info.GetValue("nullableInt", typeof(int?));
+
+            _booleanValue = info.GetBoolean("booleanValue");
+            _byteValue = info.GetByte("byteValue");
+            _charValue = info.GetChar("charValue");
+            _dateTimeValue = info.GetDateTime("dateTimeValue");
+            _decimalValue = info.GetDecimal("decimalValue");
+            _shortValue = info.GetInt16("shortValue");
+            _longValue = info.GetInt64("longValue");
+            _sbyteValue = info.GetSByte("sbyteValue");
+            _floatValue = info.GetSingle("floatValue");
+            _ushortValue = info.GetUInt16("ushortValue");
+            _uintValue = info.GetUInt32("uintValue");
+            _ulongValue = info.GetUInt64("ulongValue");
+        }
+
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue((string)"stringValue", (object)_stringValue);
+            info.AddValue((string)"intValue", (int)_intValue);
+            info.AddValue((string)"dateTimeOffsetValue", (object)_dateTimeOffsetValue);
+            info.AddValue((string)"personValue", (object)_personValue);
+            info.AddValue((string)"nullPersonValue", (object)_nullPersonValue);
+            info.AddValue("nullableInt", null);
+
+            info.AddValue((string)"booleanValue", (bool)_booleanValue);
+            info.AddValue((string)"byteValue", (byte)_byteValue);
+            info.AddValue((string)"charValue", (char)_charValue);
+            info.AddValue((string)"dateTimeValue", (DateTime)_dateTimeValue);
+            info.AddValue((string)"decimalValue", (decimal)_decimalValue);
+            info.AddValue((string)"shortValue", (short)_shortValue);
+            info.AddValue((string)"longValue", (long)_longValue);
+            info.AddValue((string)"sbyteValue", (sbyte)_sbyteValue);
+            info.AddValue((string)"floatValue", (float)_floatValue);
+            info.AddValue((string)"ushortValue", (ushort)_ushortValue);
+            info.AddValue((string)"uintValue", (uint)_uintValue);
+            info.AddValue((string)"ulongValue", (ulong)_ulongValue);
+        }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/ISerializableWithoutAttributeTestObject.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/ISerializableWithoutAttributeTestObject.cs
@@ -1,0 +1,38 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class ISerializableWithoutAttributeTestObject : ISerializable
+    {
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/MultipleParametrizedConstructorsJsonConstructor.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/MultipleParametrizedConstructorsJsonConstructor.cs
@@ -1,0 +1,48 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public class MultipleParametrizedConstructorsJsonConstructor
+    {
+        public string Value { get; private set; }
+        public int Age { get; private set; }
+        public string Constructor { get; private set; }
+
+        public MultipleParametrizedConstructorsJsonConstructor(string value)
+        {
+            Value = value;
+            Constructor = "Public Parameterized 1";
+        }
+
+        [JsonConstructor]
+        public MultipleParametrizedConstructorsJsonConstructor(string value, int age)
+        {
+            Value = value;
+            Age = age;
+            Constructor = "Public Parameterized 2";
+        }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/Employee.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/Employee.cs
@@ -1,0 +1,39 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+
+namespace Newtonsoft.Json.Tests.TestObjects.Organization
+{
+    public class Employee : IPerson
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public DateTime BirthDate { get; set; }
+
+        public string Department { get; set; }
+        public string JobTitle { get; set; }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/IPerson.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/IPerson.cs
@@ -1,0 +1,36 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+
+namespace Newtonsoft.Json.Tests.TestObjects.Organization
+{
+    public interface IPerson
+    {
+        string FirstName { get; set; }
+        string LastName { get; set; }
+        DateTime BirthDate { get; set; }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/Person.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/Organization/Person.cs
@@ -1,0 +1,54 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.ComponentModel;
+
+namespace Newtonsoft.Json.Tests.TestObjects.Organization
+{
+    [JsonObject(Id = "Person", Title = "Title!", Description = "JsonObjectAttribute description!", MemberSerialization = MemberSerialization.OptIn)]
+#if !(DNXCORE50)
+    [Description("DescriptionAttribute description!")]
+#endif
+    public class Person
+    {
+        // "John Smith"
+        [JsonProperty]
+        public string Name { get; set; }
+
+        // "2000-12-15T22:11:03"
+        [JsonProperty]
+        //[JsonConverter(typeof(IsoDateTimeConverter))]
+        public DateTime BirthDate { get; set; }
+
+        // new Date(976918263055)
+        [JsonProperty]
+        //[JsonConverter(typeof(JavaScriptDateTimeConverter))]
+        public DateTime LastModified { get; set; }
+
+        // not serialized
+        public string Department { get; set; }
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/TestObjects/StructTest.cs
+++ b/test/ZCS.DataContractResolver.Tests/TestObjects/StructTest.cs
@@ -1,0 +1,35 @@
+#region License
+// Copyright (c) 2007 James Newton-King
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+#endregion
+
+namespace Newtonsoft.Json.Tests.TestObjects
+{
+    public struct StructTest
+    {
+        public string StringProperty { get; set; }
+        public string StringField;
+        public int IntProperty { get; set; }
+        public int IntField;
+    }
+}

--- a/test/ZCS.DataContractResolver.Tests/ZCS.DataContractResolver.Tests.csproj
+++ b/test/ZCS.DataContractResolver.Tests/ZCS.DataContractResolver.Tests.csproj
@@ -6,12 +6,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="NUnit.Analyzers" />
     <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #61 

Apparently this approach will serialize fine without a required field, but throw a `JsonException` during deserialization.

Based on #60 so merge that first. See the latest commit for the changes related to `RequiredAttribute`

EDIT: Looks like there's also an [IsRequired](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.datamemberattribute.isrequired?view=net-8.0) property on the `DataMemberAttribute` and one might argue that only that one should be supported in this library.

Newtonsoft seems to support both.